### PR TITLE
Provide ability to expose server on LAN and add shebang line

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+
 import utils.gradio_ui as gradio_ui
 import utils.agent as agent_utils
 
 def main():
+    SERVER_NAME = os.getenv('SERVER_NAME')
 
     try:
       mcp_client = agent_utils.initialize_mcp_client()
       agent = agent_utils.initialize_agent(mcp_client)
       demo = gradio_ui.get_gradio_interface(agent)
 
-      demo.launch()
+      demo.launch(server_name=SERVER_NAME)
     finally:
       mcp_client.disconnect()
 


### PR DESCRIPTION
Also made app.py executable (chmod +x)

Tested:
- `./app.py` will run the server bound to localhost only
- `SERVER_NAME=0.0.0.0 ./app.py` will bind the HTTP server across LAN so it can be accessed from another computer