### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ pyproject.toml
 uv.lock
 node_modules/
 package*
-*db
+*.db
+*.env


### PR DESCRIPTION
This makes it easy to persist model and backend parameters in the .env file and then use `uv run ./app.py` which will automatically read it.